### PR TITLE
Add cookie container to begin caching of avatar images.

### DIFF
--- a/DevOps.Plugin/UI/ViewModels/PullRequestPageVM.cs
+++ b/DevOps.Plugin/UI/ViewModels/PullRequestPageVM.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -51,7 +52,13 @@ namespace DevOps.UI.ViewModels
 
             this.avatars = new Dictionary<Uri, ImageSource>();
             this.pendingAvatars = new Dictionary<Uri, List<IAvatarSite>>();
-            this.avatarHttpClient = new HttpClient();
+
+            // Cookie container is used so we can get caching on avatar images
+            CookieContainer cookies = new CookieContainer();
+            HttpClientHandler handler = new HttpClientHandler();
+            handler.CookieContainer = cookies;
+
+            this.avatarHttpClient = new HttpClient(handler);
             this.avatarHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", userContext.AuthenticationResult.AccessToken);
             this.avatarHttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("image/png"));
         }


### PR DESCRIPTION
Cached images should return 304 (Not Modified). This right now is only using the cookie container to store the cookies as a beginning step and returning a 200. Images are still not cached but a lot of the headers are set to continue this work later on.

Consider looking into using Etag. 